### PR TITLE
Add startup script for automatic deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.git
+.gitignore
+node_modules

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Authenticate Docker
+        run: gcloud auth configure-docker --quiet
+
+      - name: Build and Push Image
+        run: |
+          IMAGE=gcr.io/${{ secrets.GCP_PROJECT_ID }}/manus-platform:${{ github.sha }}
+          docker build -t $IMAGE .
+          docker push $IMAGE
+
+      - name: Deploy to VM
+        run: |
+          gcloud compute ssh ${{ secrets.GCP_VM_NAME }} \
+            --zone ${{ secrets.GCP_VM_ZONE }} \
+            --command "docker pull gcr.io/${{ secrets.GCP_PROJECT_ID }}/manus-platform:${{ github.sha }} && \\
+                      docker stop manus || true && \\
+                      docker rm manus || true && \\
+                      docker run -d --name manus -p 5000:5000 \\
+                        gcr.io/${{ secrets.GCP_PROJECT_ID }}/manus-platform:${{ github.sha }}"

--- a/Automate Manus-style AI deployment process.md
+++ b/Automate Manus-style AI deployment process.md
@@ -1,0 +1,36 @@
+# Automating Manus-Style AI Deployment
+
+This guide explains the GitHub Actions workflow used to build and deploy the Manus-style platform to a Google Cloud VM. Follow these instructions to enable fully automated deployments.
+
+## 1. Required Secrets
+Add the following secrets to your GitHub repository settings:
+
+- `GCP_PROJECT_ID` – Google Cloud project ID (e.g. `blissful-epoch-467811-i3`)
+- `GCP_SA_KEY` – JSON service account key with permissions for Compute Engine and Container Registry
+- `GCP_VM_NAME` – Name of the target Compute Engine VM (e.g. `manus-vm`)
+- `GCP_VM_ZONE` – Zone where the VM resides (e.g. `us-west2-c`)
+
+## 2. Workflow Overview
+On every push to the `main` branch, the workflow performs these steps:
+
+1. **Checkout** – Retrieve repository source
+2. **Set up Cloud SDK** – Authenticate to GCP using the service account
+3. **Authenticate Docker** – Enable pushes to Google Container Registry
+4. **Build and Push Image** – Build the Docker image and push to `gcr.io/<PROJECT_ID>/manus-platform:<commit>`
+5. **Deploy to VM** – SSH to the VM, pull the new image, stop the old container, and run the updated container exposing port 5000
+
+## 3. VM Requirements
+Ensure the Compute Engine VM:
+- Runs Docker and allows SSH access
+- Opens port `5000` in its firewall rules for API access
+- Has sufficient resources to run the container
+
+## 4. Manual Steps
+While the workflow automates deployment, some actions must be done manually:
+- Provision the VM and install Docker
+- Upload the service account key to GitHub Secrets
+- Update secrets if keys or VM names change
+
+## 5. Triggering Deployments
+Commit to `main` or merge pull requests. The GitHub Actions workflow builds the image and redeploys automatically. Monitor the **Actions** tab for logs and verify the service at `http://<VM_EXTERNAL_IP>:5000`.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Dockerfile for Manus-style platform
+# Builds a container image for the Flask backend
+
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose backend port
+EXPOSE 5000
+
+# Start the application
+CMD ["python", "main.py"]

--- a/gcloud-deploy.sh
+++ b/gcloud-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build and deploy the Manus-style platform container to a Google Cloud VM.
 # Usage: ./gcloud-deploy.sh <PROJECT_ID> <VM_NAME> <ZONE>
 
@@ -24,3 +24,4 @@ gcloud compute ssh "$VM_NAME" --project "$PROJECT_ID" --zone "$ZONE" --command "
     docker rm manus || true && \
     docker run -d --name manus -p 5000:5000 $IMAGE
 "
+

--- a/gcloud-deploy.sh
+++ b/gcloud-deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Build and deploy the Manus-style platform container to a Google Cloud VM.
+# Usage: ./gcloud-deploy.sh <PROJECT_ID> <VM_NAME> <ZONE>
+
+set -euo pipefail
+
+PROJECT_ID=${1:?"project id required"}
+VM_NAME=${2:?"vm name required"}
+ZONE=${3:?"zone required"}
+
+IMAGE="gcr.io/${PROJECT_ID}/manus-platform:latest"
+
+# Build and push image to Google Container Registry
+if ! command -v gcloud >/dev/null 2>&1; then
+    echo "gcloud not installed" >&2
+    exit 1
+fi
+
+gcloud builds submit --tag "$IMAGE" .
+
+gcloud compute ssh "$VM_NAME" --project "$PROJECT_ID" --zone "$ZONE" --command "\
+    docker pull $IMAGE && \
+    docker stop manus || true && \
+    docker rm manus || true && \
+    docker run -d --name manus -p 5000:5000 $IMAGE
+"

--- a/startup.sh
+++ b/startup.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Startup script for manus-vm to deploy the Sophia Manus clone platform
 # Installs dependencies, clones repository, and launches backend and frontend
 # Intended for use as a GCE metadata startup-script
-set -e
+set -euo pipefail
 
 # Update system and install prerequisites
 apt-get update -y
@@ -39,3 +39,4 @@ if [ -d manus_platform_frontend ]; then
   npm install
   nohup npm run dev -- --host >/var/log/sophia-frontend.log 2>&1 &
 fi
+

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Startup script for manus-vm to deploy the Sophia Manus clone platform
+# Installs dependencies, clones repository, and launches backend and frontend
+# Intended for use as a GCE metadata startup-script
+set -e
+
+# Update system and install prerequisites
+apt-get update -y
+apt-get install -y python3 python3-venv python3-pip git nodejs npm unzip
+
+# Clone repository if not already present
+REPO_DIR="/opt/sophia"
+if [ ! -d "$REPO_DIR" ]; then
+  git clone https://github.com/chosen8823/sophia.git "$REPO_DIR"
+fi
+
+cd "$REPO_DIR"
+
+# Unpack any bundled archives (if present)
+for archive in *.zip; do
+  [ -f "$archive" ] && unzip -o "$archive"
+done
+
+# Python environment setup
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+if [ -f requirements.txt ]; then
+  pip install -r requirements.txt
+fi
+
+# Launch backend
+nohup bash -c "source $REPO_DIR/venv/bin/activate && python main.py" \
+  >/var/log/sophia-backend.log 2>&1 &
+
+# Launch frontend if available
+if [ -d manus_platform_frontend ]; then
+  cd manus_platform_frontend
+  npm install
+  nohup npm run dev -- --host >/var/log/sophia-frontend.log 2>&1 &
+fi


### PR DESCRIPTION
## Summary
- add startup script to install dependencies, clone repository, and start backend/frontend for the Manus-style platform

## Testing
- `bash -n startup.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d40e196e88324a918230f349ffb18